### PR TITLE
vector outline and raster methods

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ fiona
 shapely
 rasterio
 setuptools
+cartopy
+matplotlib


### PR DESCRIPTION
This PR adds:
- vector grid outline. (A lighter way to plot the grid as a vector layer.)
- raster representation (numpy array) of the grid.
- caching of expensive computations.

Note to self: the raster representation should be using `rasterio` rather than the convoluted `matplotlib`+`cartopy` hackish way I have now.