### PR TITLE
Python 3 tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 
 env:
     - CONDA="python=2.7"
-    #- CONDA="python=3.4"
-    #- CONDA="python=3.5"
+    - CONDA="python=3.4"
+    - CONDA="python=3.5"
 
 before_install:
     - wget http://bit.ly/miniconda -O miniconda.sh
@@ -14,10 +14,10 @@ before_install:
     - travis_retry conda create --yes -n TEST $CONDA --file requirements.txt
     - source activate TEST
     - conda install --yes --file requirements-dev.txt
-    # GUI
+    # GUI.
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
 
 script:
-    - python setup.py test
+    - python setup.py test -a "--verbose"
     - find . -type f -name "*.py" | xargs flake8 --max-line-length=100

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
 gridgeo
 -------
 
-Convert UGRID and SGRID compliant files to a variety of geo-like objects.
-The formats currently supported are TopoJSON, GeoJSON, and Shapefile.
+Convert ocean numerical models grids,
+including UGRID and SGRID compliant files,
+to a variety of geo-like objects (GeoJSON, TopoJSON, and Shapefile).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 flake8
 pytest
+cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+netCDF4 >=1.2.0,<1.2.2
 pysgrid
 pyugrid
 fiona

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,16 @@ from setuptools.command.test import test as TestCommand
 
 
 class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.verbose = True
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
 
     def run_tests(self):
+        # Import here, cause outside the eggs aren't loaded.
         import pytest
-        errno = pytest.main(self.test_args)
+        errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
 


### PR DESCRIPTION
Enable Python 3 tests now that iris is finally py3k compat.