### PR TITLE
command line saver

### DIFF
--- a/gridgeo/gridio.py
+++ b/gridgeo/gridio.py
@@ -1,0 +1,47 @@
+
+from docopt import docopt
+
+from gridgeo import GridGeo
+
+__doc__ = """
+Save a GeoJSON or ESRI Shapefile representation of an ocean model grid.
+
+Usage:
+    gridio URL VAR --output=OUTFILE
+
+    gridio (-h | --help -o | --output)
+
+Examples:
+    gridio netcdf-file.nc sea_water_temperature --output=grid.shp
+    gridio remote-opendap-url sea_water_temperature --output=grid.geojson
+
+Arguments:
+  directory               Configuration directory.
+
+Options:
+  -h --help                       Show this screen.
+  -o OUTFILE --output=OUTFILE     Output file
+"""
+
+
+def parse_args():
+    args = docopt(__doc__)
+    return args
+
+
+def cli(args):
+    url = args.get('URL')
+    standard_name = args.get('VAR')
+    filename = args.get('--output')
+
+    grid = GridGeo(url, standard_name=standard_name)
+    grid.save(filename, float_precision=4)
+
+
+def main():
+    args = parse_args()
+    cli(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -22,27 +22,32 @@ with open('requirements.txt') as f:
     require = f.readlines()
 install_requires = [r.strip() for r in require]
 
-setup(name='gridgeo',
-      version=versioneer.get_version(),
-      license=LICENSE,
-      long_description=long_description,
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Environment :: Console',
-          'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: MIT License',
-          'Operating System :: OS Independent',
-          'Programming Language :: Python :: 3.6',
-          'Topic :: Scientific/Engineering',
-          ],
-      description=('Convert UGRID, SGRID, and some non-compliant ocean model grids to geo-like objects'),  # noqa
-      url='https://github.com/pyoceans/gridgeo',
-      platforms='any',
-      keywords=['geojson', 'ocean models', 'ugrid', 'sgrid'],
-      install_requires=install_requires,
-      packages=['gridgeo'],
-      tests_require=['pytest'],
-      cmdclass=versioneer.get_cmdclass(),
-      author=['Filipe Fernandes'],
-      author_email='ocefpaf@gmail.com',
-      )
+setup(
+    name='gridgeo',
+    version=versioneer.get_version(),
+    license=LICENSE,
+    long_description=long_description,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Console',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Scientific/Engineering',
+        ],
+    description=('Convert UGRID, SGRID, and some non-compliant ocean model grids to geo-like objects'),  # noqa
+    url='https://github.com/pyoceans/gridgeo',
+    platforms='any',
+    keywords=['geojson', 'shapefile', 'ocean models', 'ugrid', 'sgrid'],
+    install_requires=install_requires,
+    packages=['gridgeo'],
+    tests_require=['pytest'],
+    cmdclass=versioneer.get_cmdclass(),
+    author=['Filipe Fernandes'],
+    author_email='ocefpaf@gmail.com',
+    entry_points={'console_scripts': [
+        'gridio = gridgeo.gridio:main',
+    ],
+    },
+)

--- a/tests/test_sgrid.py
+++ b/tests/test_sgrid.py
@@ -1,6 +1,6 @@
-import numpy as np
-
 import gridgeo
+
+import numpy as np
 
 from shapely.geometry import MultiPolygon, Polygon
 
@@ -31,8 +31,8 @@ def test_outline():
 
 def test_polygons():
     assert isinstance(grid.polygons, _iterables)
-    assert all([isinstance(p, _iterables) for p in grid.polygons])
-    assert all([len(p) == 4 for p in grid.polygons])
+    assert all((isinstance(p, _iterables) for p in grid.polygons))
+    assert all((len(p) == 4 for p in grid.polygons))
 
 
 def test_geometry():

--- a/tests/test_ugrid.py
+++ b/tests/test_ugrid.py
@@ -1,6 +1,6 @@
-import numpy as np
-
 import gridgeo
+
+import numpy as np
 
 from shapely.geometry import MultiPolygon, Polygon
 
@@ -31,8 +31,8 @@ def test_outline():
 
 def test_polygons():
     assert isinstance(grid.polygons, _iterables)
-    assert all([isinstance(p, _iterables) for p in grid.polygons])
-    assert all([len(p) == 3 for p in grid.polygons])
+    assert all((isinstance(p, _iterables) for p in grid.polygons))
+    assert all((len(p) == 3 for p in grid.polygons))
 
 
 def test_geometry():

--- a/tests/test_unknown_1d.py
+++ b/tests/test_unknown_1d.py
@@ -1,6 +1,6 @@
-import numpy as np
-
 import gridgeo
+
+import numpy as np
 
 from shapely.geometry import MultiPolygon, Polygon
 
@@ -30,8 +30,8 @@ def test_outline():
 
 def test_polygons():
     assert isinstance(grid.polygons, _iterables)
-    assert all([isinstance(p, _iterables) for p in grid.polygons])
-    assert all([len(p) == 4 for p in grid.polygons])
+    assert all((isinstance(p, _iterables) for p in grid.polygons))
+    assert all((len(p) == 4 for p in grid.polygons))
 
 
 def test_geometry():

--- a/tests/test_unknown_2d.py
+++ b/tests/test_unknown_2d.py
@@ -1,6 +1,6 @@
-import numpy as np
-
 import gridgeo
+
+import numpy as np
 
 from shapely.geometry import MultiPolygon, Polygon
 
@@ -31,8 +31,8 @@ def test_outline():
 
 def test_polygons():
     assert isinstance(grid.polygons, _iterables)
-    assert all([isinstance(p, _iterables) for p in grid.polygons])
-    assert all([len(p) == 4 for p in grid.polygons])
+    assert all((isinstance(p, _iterables) for p in grid.polygons))
+    assert all((len(p) == 4 for p in grid.polygons))
 
 
 def test_geometry():


### PR DESCRIPTION
Closes https://github.com/pyoceans/gridgeo/issues/2

We can either save all grids or use the logic of loading one grid per variable. The format can be costly while the later, even though has a complex logic and an extra step, lines up nicely with the python API.

Right now the variables are identified using `standard_name`s, more options when we refactor the `CFVariable` to make it more flexible.