### PR TITLE
feat: change tests workflow to Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [hacktoberfest2022:test_github_actions]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Micromamba
+      uses: mamba-org/provision-with-micromamba@v13
+      with:
+        environment-file: false
+
+    - name: Python ${{ matrix.python-version }}
+      shell: bash -l {0}
+      run: |
+        micromamba create --yes --name TEST python=${{ matrix.python-version }} pip python-build --file requirements.txt --file requirements-dev.txt --channel conda-forge
+        micromamba activate TEST
+        pip install -e . --no-deps --force-reinstall
+    - name: Tarball tests
+      shell: bash -l {0}
+      run: |
+        micromamba activate TEST
+        python setup.py --version
+        python -m build --sdist --wheel . --outdir dist
+        check-manifest --verbose
+        twine check dist/*
+    - name: Tests
+      shell: bash -l {0}
+      run: |
+        micromamba activate TEST
+        pytest -rxs --cov=gridgeo tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,17 +25,10 @@ jobs:
     - name: Python ${{ matrix.python-version }}
       shell: bash -l {0}
       run: |
-        micromamba create --yes --name TEST python=${{ matrix.python-version }} pip python-build --file requirements.txt --file requirements-dev.txt --channel conda-forge
+        micromamba create --yes --name TEST python=${{ matrix.python-version }} --file requirements.txt --file requirements-dev.txt --channel conda-forge
         micromamba activate TEST
         pip install -e . --no-deps --force-reinstall
-    - name: Tarball tests
-      shell: bash -l {0}
-      run: |
-        micromamba activate TEST
-        python setup.py --version
-        python -m build --sdist --wheel . --outdir dist
-        check-manifest --verbose
-        twine check dist/*
+
     - name: Tests
       shell: bash -l {0}
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   pull_request:
   push:
-    branches: [hacktoberfest2022-test_github_actions]
+    branches: [main]
 
 jobs:
   run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   pull_request:
   push:
-    branches: [hacktoberfest2022:test_github_actions]
+    branches: [hacktoberfest2022-test_github_actions]
 
 jobs:
   run:


### PR DESCRIPTION
Changing tests pipeline to GitHub Actions, to test the package in windows, ubuntu, and macOS for several python versions (3.7, 3.8, 3.9, and 3.10), every time a push is sent to the main branch.

Note that I kept the `.travis.yml` file because it contains the documentation workflow and I intend to create a new file specifically for this.

