### PR TITLE
feat: moving documentation workflow from travis to github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   pull_request:
   push:
-    branches: [hacktoberfest2022-documentation_github_actions]
+    branches: [main]
 
 jobs:
   run:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ jobs:
         micromamba create --yes --name TEST python=${{ matrix.python-version }} --file requirements.txt --file requirements-dev.txt --channel conda-forge
         micromamba activate TEST
         pip install -e . --no-deps --force-reinstall
+        apt-get install python3-sphinx
 
     # steps:
     # - uses: actions/checkout@v3
@@ -48,15 +49,16 @@ jobs:
     #       version=$(python setup.py --version)
     #       pip install --no-deps --force-reinstall gridgeo-${version}.tar.gz
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v3
 
-    # - name: Building sphinx
-    #   shell: bash -l {0}
-    #   run: |
-    #       micromamba activate TEST
-    #       cp notebooks/gridgeo_tour.ipynb docs/source/
-    #       cd docs/source
+    - name: Building sphinx
+      shell: bash -l {0}
+      run: |
+          micromamba activate TEST
+          cp notebooks/gridgeo_tour.ipynb docs/source/
+          cd docs
+          make clean html linkcheck
     #       "sphinx-build -b html ../build/html"
 
     # - name: Build sphinx documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Building documentation with sphinx
       shell: bash -l {0}
       run: |
+        micromamba activate TEST
         set -e
         cp notebooks/gridgeo_tour.ipynb docs/source
         pushd docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,22 +7,57 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest] #, windows-latest, macos-latest
+        python-version: ["3.7"] #, "3.8", "3.9", "3.10"
+      fail-fast: false
     steps:
     - uses: actions/checkout@v3
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        pre-build-command: "set -e; cp notebooks/gridgeo_tour.ipynb docs/source/; pushd docs; make clean html linkcheck"
-        build-command: "sphinx-build -b html . docs/build/html"
-        docs-folder: "docs/"
 
-    # - name: Documentation
-    #   shell: bash -l {0}
+    - name: Setup Micromamba
+      uses: mamba-org/provision-with-micromamba@v13
+      with:
+        environment-file: false
+
+    - name: Python ${{ matrix.python-version }}
+      shell: bash -l {0}
+      run: |
+        micromamba create --yes --name TEST python=${{ matrix.python-version }} --file requirements.txt --file requirements-dev.txt --channel conda-forge
+        micromamba activate TEST
+        pip install -e . --no-deps --force-reinstall
+
+    # steps:
+    # - uses: actions/checkout@v3
+    # - name: Install dependencies
     #   run: |
-    #     set -e ;
-    #     cp notebooks/gridgeo_tour.ipynb docs/source/ ;
-    #     pushd docs ;
-    #     make clean html linkcheck ;
-    #     popd ;
-    #     python -m doctr deploy --sync .;
-    #     python -m doctr deploy --sync --no-require-master --built-docs docs/build/html "docs-main" ;
+    #       wget http://bit.ly/miniconda -O miniconda.sh
+    #       bash miniconda.sh -b -p $HOME/miniconda
+    #       export PATH="$HOME/miniconda/bin:$PATH"
+    #       conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
+    #       conda update --quiet conda
+    #       conda config --add channels conda-forge --force
+    #       conda config --remove channels defaults
+    #       conda create --name TEST python=3.7 --file requirements.txt --file requirements-dev.txt
+    #       source activate TEST
+
+    # - name: Installing gridgeo and its dependencies
+    #   run: |
+    #       python setup.py sdist
+    #       version=$(python setup.py --version)
+    #       pip install --no-deps --force-reinstall gridgeo-${version}.tar.gz
+
+    - name: Building sphinx
+      run: |
+          micromamba activate TEST
+          cp notebooks/gridgeo_tour.ipynb docs/source/
+          cd docs/source
+          "sphinx-build -b html ../build/html"
+
+    # - name: Build sphinx documentation
+    # - uses: ammaraskar/sphinx-action@master
+    #   with:
+    #     pre-build-command: "cp notebooks/gridgeo_tour.ipynb docs/source/; cd docs/source"
+    #     build-command: "sphinx-build -b html . ../build/html"
+    #     docs-folder: "docs/"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v3
 
     - name: Setup Micromamba
       uses: mamba-org/provision-with-micromamba@v13

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
         popd
 
     - name: Deploy docs to gh-pages
-      uses: peaceiris/actions-gh-pages@v3.8.0
+      uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.TOKEN_GHA }}
         publish_dir: docs/build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Deploy docs to gh-pages
       uses: peaceiris/actions-gh-pages@v3
       with:
-        github_token: ${{ secrets.TOKEN_GHA }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,63 +7,31 @@ on:
 
 jobs:
   run:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest] #, windows-latest, macos-latest
-        python-version: ["3.7"] #, "3.8", "3.9", "3.10"
-      fail-fast: false
+    runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.1.0
 
     - name: Setup Micromamba
       uses: mamba-org/provision-with-micromamba@v13
       with:
         environment-file: false
 
-    - name: Python ${{ matrix.python-version }}
+    - name: Setting environment configuration
       shell: bash -l {0}
       run: |
-        micromamba create --yes --name TEST python=${{ matrix.python-version }} --file requirements.txt --file requirements-dev.txt --channel conda-forge
+        micromamba create --yes --name TEST python=3.7 --file requirements.txt --file requirements-dev.txt --channel conda-forge
         micromamba activate TEST
         pip install -e . --no-deps --force-reinstall
-        apt-get install python3-sphinx
 
-    # steps:
-    # - uses: actions/checkout@v3
-    # - name: Install dependencies
-    #   run: |
-    #       wget http://bit.ly/miniconda -O miniconda.sh
-    #       bash miniconda.sh -b -p $HOME/miniconda
-    #       export PATH="$HOME/miniconda/bin:$PATH"
-    #       conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
-    #       conda update --quiet conda
-    #       conda config --add channels conda-forge --force
-    #       conda config --remove channels defaults
-    #       conda create --name TEST python=3.7 --file requirements.txt --file requirements-dev.txt
-    #       source activate TEST
-
-    # - name: Installing gridgeo and its dependencies
-    #   run: |
-    #       python setup.py sdist
-    #       version=$(python setup.py --version)
-    #       pip install --no-deps --force-reinstall gridgeo-${version}.tar.gz
-
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3
-
-    - name: Building sphinx
+    - name: Building documentation with sphinx
       shell: bash -l {0}
       run: |
-          micromamba activate TEST
-          cp notebooks/gridgeo_tour.ipynb docs/source/
-          cd docs
-          make clean html linkcheck
-    #       "sphinx-build -b html ../build/html"
+        set -e
+        cp notebooks/gridgeo_tour.ipynb docs/source
+        pushd docs
+        make clean html linkcheck
+        popd
 
-    # - name: Build sphinx documentation
-    # - uses: ammaraskar/sphinx-action@master
-    #   with:
-    #     pre-build-command: "cp notebooks/gridgeo_tour.ipynb docs/source/; cd docs/source"
-    #     build-command: "sphinx-build -b html . ../build/html"
-    #     docs-folder: "docs/"
+    # - name: Deploy docs to gh-pages
+      

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,7 @@ jobs:
     #       pip install --no-deps --force-reinstall gridgeo-${version}.tar.gz
 
     - name: Building sphinx
+      shell: bash -l {0}
       run: |
           micromamba activate TEST
           cp notebooks/gridgeo_tour.ipynb docs/source/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,13 +48,16 @@ jobs:
     #       version=$(python setup.py --version)
     #       pip install --no-deps --force-reinstall gridgeo-${version}.tar.gz
 
-    - name: Building sphinx
-      shell: bash -l {0}
-      run: |
-          micromamba activate TEST
-          cp notebooks/gridgeo_tour.ipynb docs/source/
-          cd docs/source
-          "sphinx-build -b html ../build/html"
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
+    # - name: Building sphinx
+    #   shell: bash -l {0}
+    #   run: |
+    #       micromamba activate TEST
+    #       cp notebooks/gridgeo_tour.ipynb docs/source/
+    #       cd docs/source
+    #       "sphinx-build -b html ../build/html"
 
     # - name: Build sphinx documentation
     # - uses: ammaraskar/sphinx-action@master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,23 +7,22 @@ on:
 
 jobs:
   run:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.7"]
-      fail-fast: false
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        pre-build-command: "set -e; cp notebooks/gridgeo_tour.ipynb docs/source/; pushd docs; make clean html linkcheck"
+        build-command: "sphinx-build -b html . docs/build/html"
+        docs-folder: "docs/"
 
-    - name: Documentation
-      shell: bash -l {0}
-      run: |
-        set -e ;
-        cp notebooks/gridgeo_tour.ipynb docs/source/ ;
-        pushd docs ;
-        make clean html linkcheck ;
-        popd ;
-        python -m doctr deploy --sync .;
-        python -m doctr deploy --sync --no-require-master --built-docs docs/build/html "docs-main" ;
+    # - name: Documentation
+    #   shell: bash -l {0}
+    #   run: |
+    #     set -e ;
+    #     cp notebooks/gridgeo_tour.ipynb docs/source/ ;
+    #     pushd docs ;
+    #     make clean html linkcheck ;
+    #     popd ;
+    #     python -m doctr deploy --sync .;
+    #     python -m doctr deploy --sync --no-require-master --built-docs docs/build/html "docs-main" ;

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,5 +34,8 @@ jobs:
         make clean html linkcheck
         popd
 
-    # - name: Deploy docs to gh-pages
-      
+    - name: Deploy docs to gh-pages
+      uses: peaceiris/actions-gh-pages@v3.8.0
+      with:
+        github_token: ${{ secrets.TOKEN_GHA }}
+        publish_dir: docs/build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Documentation
+
+on:
+  pull_request:
+  push:
+    branches: [hacktoberfest2022-documentation_github_actions]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Documentation
+      shell: bash -l {0}
+      run: |
+        set -e ;
+        cp notebooks/gridgeo_tour.ipynb docs/source/ ;
+        pushd docs ;
+        make clean html linkcheck ;
+        popd ;
+        python -m doctr deploy --sync .;
+        python -m doctr deploy --sync --no-require-master --built-docs docs/build/html "docs-main" ;

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,10 @@ name: Documentation
 
 on:
   pull_request:
+
   push:
-    branches: [main]
+    tags:
+      - "v*"
 
 jobs:
   run:
@@ -20,7 +22,7 @@ jobs:
     - name: Setting environment configuration
       shell: bash -l {0}
       run: |
-        micromamba create --yes --name TEST python=3.7 --file requirements.txt --file requirements-dev.txt --channel conda-forge
+        micromamba create --yes --name TEST python=3 --file requirements.txt --file requirements-dev.txt --channel conda-forge
         micromamba activate TEST
         pip install -e . --no-deps --force-reinstall
 
@@ -35,6 +37,7 @@ jobs:
         popd
 
     - name: Deploy docs to gh-pages
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In this PR, I am moving the documentation workflow to GitHub Actions. Note that a GitHub token is necessary to deploy the documentation to the gh-page branch. I believe the maintainers must configure this token as repository secrets.

I am also deleting the travis.yml and *.enc files since they are deprecated with these new workflows (test and docs).